### PR TITLE
Abhängigkeit von Modelclass je Tabelle entfernt

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -56,9 +56,9 @@
                     }, function (resp) {
                         $('#rex-js-ajax-loader').removeClass('rex-visible');
 
-                        if (resp.length)
+                        if (resp.length && window.console)
                         {
-                            alert(resp);
+                            console.log(resp);
                         }
                     });
                 }

--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -1,10 +1,9 @@
 .sortable-list {
     .status-toggle {
-        cursor:pointer;
+        cursor: pointer;
     }
     .sort-handle:hover {
-        transform: scale(1.3);
-        transform-origin: 10px 10px;
+        color: #4b9ad9;
         cursor: move;
     }
 }

--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -10,6 +10,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace yform\usability;
 
 
@@ -17,22 +18,26 @@ class Extensions
 {
     public static function yform_data_list($params)
     {
-        $list      = $params->getSubject();
-        $table     = $params->getParam('table');
-        $config    = \rex_addon::get('yform_usability')->getConfig(null, []);
+        $list = $params->getSubject();
+        $table = $params->getParam('table');
+        $default_config = \rex_addon::get('yform_usability')->getProperty('default_config');
+        $config = \rex_addon::get('yform_usability')->getConfig(null, $default_config);
         $is_opener = rex_get('rex_yform_manager_opener', 'array');
 
-        $has_duplicate = count((array) $config['duplicate_tables']) && (in_array('all', $config['duplicate_tables']) || in_array($table->getTableName(), $config['duplicate_tables']));
-        $has_status    = count((array) $config['status_tables']) && (in_array('all', $config['status_tables']) || in_array($table->getTableName(), $config['status_tables']));
-        $has_sorting   = count((array) $config['sorting_tables']) && (in_array('all', $config['sorting_tables']) || in_array($table->getTableName(), $config['sorting_tables']));
+        $has_duplicate = count((array)$config['duplicate_tables']) && (in_array('all', $config['duplicate_tables']) || in_array($table->getTableName(), $config['duplicate_tables']));
+        $has_status = count((array)$config['status_tables']) && (in_array('all', $config['status_tables']) || in_array($table->getTableName(), $config['status_tables']));
+        $has_sorting = count((array)$config['sorting_tables']) && (in_array('all', $config['sorting_tables']) || in_array($table->getTableName(), $config['sorting_tables']));
 
-        if ($has_duplicate && empty ($is_opener) && \rex_extension::registerPoint(new \rex_extension_point('yform/usability.addDuplication', true, ['list' => $list, 'table' => $table]))) {
+        if ($has_duplicate && empty ($is_opener) && \rex_extension::registerPoint(new \rex_extension_point('yform/usability.addDuplication', true, ['list' => $list, 'table' => $table])))
+        {
             $list = self::addDuplication($list, $table);
         }
-        if ($has_status && count($table->getFields(['name' => 'status'])) && \rex_extension::registerPoint(new \rex_extension_point('yform/usability.addStatusToggle', true, ['list' => $list, 'table' => $table]))) {
+        if ($has_status && count($table->getFields(['name' => 'status'])) && \rex_extension::registerPoint(new \rex_extension_point('yform/usability.addStatusToggle', true, ['list' => $list, 'table' => $table])))
+        {
             $list = self::addStatusToggle($list, $table);
         }
-        if ($has_sorting && empty ($is_opener) && count($table->getFields(['name' => 'prio'])) && \rex_extension::registerPoint(new \rex_extension_point('yform/usability.addDragNDropSort', true, ['list' => $list, 'table' => $table]))) {
+        if ($has_sorting && empty ($is_opener) && count($table->getFields(['name' => 'prio'])) && \rex_extension::registerPoint(new \rex_extension_point('yform/usability.addDragNDropSort', true, ['list' => $list, 'table' => $table])))
+        {
             $list = self::addDragNDropSort($list, $table);
         }
         return $list;
@@ -42,13 +47,14 @@ class Extensions
     {
         $list->addColumn('packing_list', '', count($list->getColumnNames()));
         $list->setColumnLabel('packing_list', 'Status');
-        $list->setColumnFormat('packing_list', 'custom', function ($params) {
+        $list->setColumnFormat('packing_list', 'custom', function ($params)
+        {
             $_status = $params['list']->getValue('status');
-            $status  = $_status ? 'online' : 'offline';
+            $status = $_status ? 'online' : 'offline';
             return '
                 <a class="status-toggle rex-' . $status . '" 
                     data-id="' . $params['list']->getValue('id') . '" 
-                    data-status="' . (int) !$_status . '"
+                    data-status="' . (int)!$_status . '"
                     data-table="' . $params['params']['table']->getTableName() . '"
                 >
                     <i class="rex-icon rex-icon-' . $status . '"></i>
@@ -61,12 +67,14 @@ class Extensions
 
     protected static function addDragNDropSort($list, $table)
     {
-        $columns        = $list->getColumnNames();
+        $columns = $list->getColumnNames();
         $first_col_name = array_shift($columns);
 
-        if ($first_col_name != 'id') {
+        if ($first_col_name != 'id')
+        {
             $list->addFormAttribute('class', 'sortable-list');
-            $list->setColumnFormat($first_col_name, 'custom', function ($params) {
+            $list->setColumnFormat($first_col_name, 'custom', function ($params)
+            {
                 $filters = \rex_extension::registerPoint(new \rex_extension_point('yform/usability.addDragNDropSort.filters', [], ['list_params' => $params]));
                 return '
                         <i class="rex-icon fa fa-bars sort-icon" 

--- a/package.yml
+++ b/package.yml
@@ -17,3 +17,8 @@ pages:
     yform/manager/yform-usability:
         title: 'yform-usability'
         hidden: true
+
+default_config:
+    duplicate_tables: []
+    status_tables: []
+    sorting_tables: []

--- a/pages/yform.manager.usability.php
+++ b/pages/yform.manager.usability.php
@@ -22,15 +22,15 @@ $_tables = \rex_yform_manager_table::getAll();
 if (rex_post('btn_save', 'string') == 'save') {
 
     // set config
-    $_config = \rex_addon::get('yform_usability')->getConfig(null, []);
+    $default_config = \rex_addon::get('yform_usability')->getProperty('default_config');
     $config  = rex_post('settings', 'array');
 
-    foreach ($_config as $key => $value) {
+    foreach ($default_config as $key => $value) {
         if (isset($config[$key])) {
             \rex_addon::get('yform_usability')->setConfig($key, $config[$key]);
         }
         else {
-            \rex_addon::get('yform_usability')->removeConfig($key);
+            \rex_addon::get('yform_usability')->setConfig($key, $default_config[$key]);
         }
     }
     $success = \rex_i18n::msg('info_updated');
@@ -69,7 +69,7 @@ $formElements = [
     [
         'label' => '<label>' . $this->i18n('label.online_status') . '</label>',
         'field' => '
-            <select name="settings[status_tables][]" class="form-control" multiple="multiple" size="8">
+            <select name="settings[status_tables][]" class="form-control" multiple="multiple" size="'.count($status_options).'">
                 ' . implode('', $status_options) . '
             </select>
         ',
@@ -77,7 +77,7 @@ $formElements = [
     [
         'label' => '<label>' . $this->i18n('label.sorting') . '</label>',
         'field' => '
-            <select name="settings[sorting_tables][]" class="form-control" multiple="multiple" size="8">
+            <select name="settings[sorting_tables][]" class="form-control" multiple="multiple" size="'.count($sorting_options).'">
                 ' . implode('', $sorting_options) . '
             </select>
         ',
@@ -85,7 +85,7 @@ $formElements = [
     [
         'label' => '<label>' . $this->i18n('label.duplication') . '</label>',
         'field' => '
-            <select name="settings[duplicate_tables][]" class="form-control" multiple="multiple" size="8">
+            <select name="settings[duplicate_tables][]" class="form-control" multiple="multiple" size="'.count($duplicate_options).'">
                 ' . implode('', $duplicate_options) . '
             </select>
         ',

--- a/pages/yform.manager.yform-usability.php
+++ b/pages/yform.manager.yform-usability.php
@@ -13,25 +13,26 @@ namespace yform\usability;
 
 $func  = rex_get('func', 'string');
 $id    = rex_get('id', 'int');
-$table = rex_get('table_name', 'string');
-$Class = \rex_yform_manager_dataset::getModelClass($table);
+$tablename = rex_get('table_name', 'string');
 
 switch ($func) {
     case 'duplicate':
-        $data = $Class::get($id)->getData();
-        unset($data['id']);
-
-        $Object = $Class::create();
-
-        foreach ($data as $key => $value) {
-            $Object->setValue($key, $value);
-        }
-        if (!$Object->save()) {
-            echo \rex_view::error(implode('<br/>', $Object->getMessages()));
-            exit;
+        $sql = \rex_sql::factory();
+        $sql->setTable($tablename);
+        $sql->setWhere('id = '.$id);
+        $sql->select('*');
+        if($sql->getRows())
+        {
+             $iSql = \rex_sql::factory();
+             $iSql->setTable($tablename);
+             foreach ($sql->getFieldNames() as $field) {
+                 if ($field != 'id') {
+                     $iSql->setValue($field, $sql->getValue($field));
+                 }
+             }
+             $iSql->insert();
         }
         break;
 }
-
-header('Location: '. \rex_url::backendPage('yform/manager/data_edit', ['table_name' => $table], false));
+header('Location: '. \rex_url::backendPage('yform/manager/data_edit', ['table_name' => $tablename], false));
 exit;


### PR DESCRIPTION
alert gegen console.log ausgetauscht, komisches CSS geändert, ein paar Variablen umbenannt, default config in der package.yml hinterlegt (gab sonst notices wenn keine Tabelle ausgewählt war).

Bei mir hat unter r5.3 und der aktuellen GH Version von yform aufgrund der fehlenden Modelclass pro Tabelle weder Prio ändern noch Duplizieren funktioniert. 