### PR TITLE
YForm 4 kompatibler yform_usability 2 Beta-Release

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: yform_usability
-version: '1.10.6'
+version: '2.0-beta1'
 author: 'Friends Of REDAXO'
 supportpage: https://github.com/FriendsOfREDAXO/yform_usability
 compile: 0
@@ -8,7 +8,7 @@ requires:
     php:
         version: '>=7, <9'
     packages:
-        yform/manager: '>=2,<4'
+        yform/manager: '^4'
 
 pages:
     yform/manager/usability:


### PR DESCRIPTION
Nach #89 #90 #91 #92 #93 #94 #95 #96 sollte YForm Usability vollends kompatibel zu YForm 4 sein. Ich konnte keine weiteren Probleme feststellen.

closes #75 
closes #87