### PR TITLE
Status-Update auf YOrm umstellen, um Zuverlässigkeit und Kompatibilität zu URL2 zu verbessern

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -21,8 +21,6 @@ Extensions::init();
         // api endpoint
         $api_result = \rex_api_yform_usability_api::factory();
 
-        \rex_api_function::handleCall();
-
         if ($api_result && $api_result->getResult()) {
             \rex_response::cleanOutputBuffers();
             \rex_response::sendContent($api_result->getResult()->toJSON(), 'application/json');

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -40,25 +40,17 @@ class rex_api_yform_usability_api extends rex_api_function
         $table   = rex_post('table', 'string');
         $sql     = rex_sql::factory();
 
-        $sql->setTable($table)->setValue('status', $status)->setWhere(['id' => $data_id]);
+        $dataset = \rex_yform_manager_dataset::get($data_id, $table);
+        $dataset->setValue('status', $status);
+
         try {
-            $sql->update();
+            $dataset->save();
         } catch (\rex_sql_exception $ex) {
-            throw new rex_api_exception($ex->getMessage());
+            throw new rex_api_exception(implode('<br>', $dataset->getMessages()));
         }
-
-
-        // flush url path file for url < 2
-        if (rex_addon::get('url')->isAvailable()) {
-            if (rex_string::versionCompare(rex_addon::get('url')->getVersion(), '2.0.0', '<')) {
-                rex_file::delete(rex_path::addonCache('url', 'pathlist.php'));
-            }
-        }
-
-
-
+        
         $modelClass = \rex_yform_manager_dataset::getModelClass($table);
-
+        /*
         if ($modelClass) {
             rex_extension::registerPoint(
                 new rex_extension_point(
@@ -72,7 +64,7 @@ class rex_api_yform_usability_api extends rex_api_function
                     ]
                 )
             );
-        }
+        } */
 
 
         $tparams = \yform\usability\Utils::getStatusColumnParams(rex_yform_manager_table::get($table), $status);

--- a/package.yml
+++ b/package.yml
@@ -15,6 +15,10 @@ pages:
         title: 'Usability'
         perm: admin[]
 
+conflicts:
+    packages:
+        url: '<2'
+        
 default_config:
     duplicate_tables: NULL
     sorting_tables: NULL


### PR DESCRIPTION
Geplant, um eigenen Status-EP überflüssig zu machen und Kompatibilität zu URL2 und anderen herzustellen. #88