### PR TITLE
FIX for view-only mode (yform permssion)

### DIFF
--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -276,7 +276,7 @@ class Extensions
             )
         );
 
-        if ($hasDuplicate && empty($isOpener) && $table->isGranted('EDIT', \rex::getUser())) {
+        if ($hasDuplicate && empty($isOpener) && $this->hasDataPageFunction('add') && $table->isGranted('EDIT', \rex::getUser())) {
             $_csrf_key = $table->getCSRFKey();
             $token = \rex_csrf_token::factory($_csrf_key)->getUrlParams();
 

--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -76,10 +76,10 @@ class Extensions
                         )
                     );
                     return '
-                        <i class="rex-icon fa fa-bars sort-icon" 
-                            data-id="###id###" 
+                        <i class="rex-icon fa fa-bars sort-icon"
+                            data-id="###id###"
                             data-table-type="orm_model"
-                            data-table="' . $params['params']['table']->getTableName() . '" 
+                            data-table="' . $params['params']['table']->getTableName() . '"
                             data-filter="' . implode(',', $filters) . '"></i>
                     ';
                 },
@@ -153,12 +153,12 @@ class Extensions
                     }
                     return '
                     <td class="rex-table-icon" style="' . $style . '">
-                        <i class="rex-icon fa fa-bars sort-icon" 
-                            data-id="###id###" 
+                        <i class="rex-icon fa fa-bars sort-icon"
+                            data-id="###id###"
                             data-table-type="db_table"
                             data-table-sort-field="prio"
                             data-table-sort-order="asc"
-                            data-table="' . $params['params']['yform_table'] . '" 
+                            data-table="' . $params['params']['yform_table'] . '"
                             data-filter="' . implode(',', $filters) . '"></i>
                     </td>
                 ';
@@ -249,7 +249,7 @@ class Extensions
                 ['list' => $list, 'table' => $table]
             )
         );
-        
+
         if ($hasStatus && count($table->getFields(['name' => 'status']))) {
             $list = self::addStatusToggle($list, $table);
         }
@@ -259,7 +259,7 @@ class Extensions
         $ep->setSubject($list);
     }
 
-    
+
     public static function yform_data_list_action_buttons(\rex_extension_point $ep)
     {
         $buttons        = $ep->getSubject();
@@ -276,7 +276,7 @@ class Extensions
             )
         );
 
-        if ($hasDuplicate && empty($isOpener) && $this->hasDataPageFunction('add') && $table->isGranted('EDIT', \rex::getUser())) {
+        if ($hasDuplicate && empty($isOpener) && $table->isGranted('EDIT', \rex::getUser())) {
             $_csrf_key = $table->getCSRFKey();
             $token = \rex_csrf_token::factory($_csrf_key)->getUrlParams();
 
@@ -291,9 +291,9 @@ class Extensions
         }
         return $buttons;
     }
-    
-    
-    
+
+
+
     public static function ext_yformDataListSql(\rex_extension_point $ep): void
     {
         if (\rex_request('yfu-action', 'string') == 'search') {
@@ -393,7 +393,7 @@ class Extensions
                                 $query    = "
                                 SELECT id
                                 FROM rex_article
-                                WHERE 
+                                WHERE
                                   name LIKE :term
                                   OR id = :id
                             ";

--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -276,7 +276,7 @@ class Extensions
             )
         );
 
-        if ($hasDuplicate && empty($isOpener)) {
+        if ($hasDuplicate && empty($isOpener) && $table->isGranted('EDIT', \rex::getUser())) {
             $_csrf_key = $table->getCSRFKey();
             $token = \rex_csrf_token::factory($_csrf_key)->getUrlParams();
 

--- a/lib/Usability.php
+++ b/lib/Usability.php
@@ -38,24 +38,26 @@ class Usability
     {
         $id        = rex_get('id', 'int');
         $tablename = rex_get('table_name', 'string');
+        $table = \rex_yform_manager_table::get($tablename);
+        if ($table->isGranted('EDIT', \rex::getUser())) {
+            if ($id > 0) {
+                $sql = \rex_sql::factory();
+                $sql->setTable($tablename);
+                $sql->setWhere('id = :id', ['id' => $id]);
+                $sql->select();
 
-        if ($id > 0) {
-            $sql = \rex_sql::factory();
-            $sql->setTable($tablename);
-            $sql->setWhere('id = :id', ['id' => $id]);
-            $sql->select();
-
-            if ($sql->getRows()) {
-                $iSql = \rex_sql::factory();
-                $iSql->setTable($tablename);
-                foreach ($sql->getFieldNames() as $field) {
-                    if ($field == 'status') {
-                        $iSql->setValue($field, 0);
-                    } elseif ($field != 'id') {
-                        $iSql->setValue($field, $sql->getValue($field));
+                if ($sql->getRows()) {
+                    $iSql = \rex_sql::factory();
+                    $iSql->setTable($tablename);
+                    foreach ($sql->getFieldNames() as $field) {
+                        if ($field == 'status') {
+                            $iSql->setValue($field, 0);
+                        } elseif ($field != 'id') {
+                            $iSql->setValue($field, $sql->getValue($field));
+                        }
                     }
+                    $iSql->insert();
                 }
-                $iSql->insert();
             }
         }
     }


### PR DESCRIPTION
preventing appearance of duplicate action button in view-only mode
TODO: double check at `public static function duplicateRow()`