### PR TITLE
addStatusToggle return type auf yform4 angepasst

### DIFF
--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -28,7 +28,7 @@ class Extensions
         }
     }
 
-    protected static function addStatusToggle($list, $table): \rex_list
+    protected static function addStatusToggle($list, $table)
     {
         /** @var \rex_list $list */
         $list->addColumn('status_toggle', '', count($list->getColumnNames()));

--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -28,9 +28,8 @@ class Extensions
         }
     }
 
-    protected static function addStatusToggle($list, $table)
+    protected static function addStatusToggle($list, $table): \rex_yform_list
     {
-        /** @var \rex_list $list */
         $list->addColumn('status_toggle', '', count($list->getColumnNames()));
         $list->setColumnLabel('status_toggle', $list->getColumnLabel('status', \rex_i18n::msg('status')));
         $list->setColumnFormat(


### PR DESCRIPTION
Rückgabe kann auch rex_yform_list sein, nicht nur rex_list. 
Siehe Code Stellen: 

https://github.com/yakamara/redaxo_yform/blob/ced8f147a76caae745281fa112b3f1a17a807efd/plugins/manager/fragments/yform/manager/page/list.php#L16
https://github.com/yakamara/redaxo_yform/blob/ced8f147a76caae745281fa112b3f1a17a807efd/plugins/manager/fragments/yform/manager/page/list.php#L175
https://github.com/FriendsOfREDAXO/yform_usability/blob/main/boot.php#L65