### PR TITLE
bugfix css lang-tabs dark-mode

### DIFF
--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -92,11 +92,7 @@
 
 .yform-lang-tabs {
     .tab-content {
-        // due to dark-mode
-        @media (prefers-color-scheme: light) {
-            background: #fff;
-        }
-
+        background: #fff;
         border-bottom: 2px solid #c1c9d4;
         padding: 20px 12px 12px 12px;
 
@@ -110,3 +106,20 @@
 .table-responsive {
     padding-bottom: 120px;
 }
+
+@mixin _dark-yform-lang-tabs {
+    .yform-lang-tabs .tab-content{
+        background: inherit;
+    }
+}
+
+body.rex-theme-dark {
+    @include _dark-yform-lang-tabs;
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.rex-theme-light) {
+        @include _dark-yform-lang-tabs;
+    }
+}
+


### PR DESCRIPTION
Bugfix, hab damals CSS Dark Mode Anpassungen gemacht. 
Die funktionierten aber nur, wenn das Betriebssystem auf Dark-Mode / Light-Mode eingestellt war. Und nicht, wenn beim Redaxo Benutzer das Theme direkt eingestellt wird.
Ist nun korrigiert, sodass dies auch berücksichtigt wird ( so wie im be_style addon).