### PR TITLE
fix: don't delete styles

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ if (\rex::isBackend() && \rex::getUser()) {
         $compiler->setCssFile($addon->getPath('assets/styles.css'));
         $compiler->compile();
         \rex_file::copy($addon->getPath('assets/styles.css'), $addon->getAssetsPath('styles.css'));
-        \rex_file::delete($addon->getPath('assets/styles.css'));
+        //\rex_file::delete($addon->getPath('assets/styles.css'));
 
         \rex_file::copy($addon->getPath('assets/vendor/Sortable.min.js'), $addon->getAssetsPath('vendor/Sortable.min.js'));
         \rex_file::copy($addon->getPath('assets/script.js'), $addon->getAssetsPath('script.js'));


### PR DESCRIPTION
Diese sollten im Assets-Ordner des Addons verbleiben da sie später eingecheckt werden müssen.