### PR TITLE
Feature: search activation configurable for specific tables

### DIFF
--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -188,10 +188,19 @@ class Extensions
     public static function ext_yformManagerDataPage(\rex_extension_point $ep): void
     {
         $manager = $ep->getSubject();
+        $config = Usability::getConfig();
 
-        if ($manager->table->isSearchable() && Usability::getConfig('use_inline_search') == '|1|') {
+        $hasSearch = $config['use_inline_search'] == '|1|' || in_array(
+                $manager->table->getTableName(),
+                explode(
+                    '|',
+                    trim($config['search_tables'] ?? '', '|')
+                )
+            );
+
+        if ($manager->table->isSearchable() && $hasSearch) {
             $functions = $manager->dataPageFunctions;
-            $sIndex    = array_search('search', $functions);
+            $sIndex = array_search('search', $functions);
 
             if ($sIndex !== false) {
                 \rex::setProperty('yform_usability.searchTableManager', $manager);

--- a/pages/yform.manager.usability.php
+++ b/pages/yform.manager.usability.php
@@ -79,12 +79,17 @@ $form->addFieldset($addon->i18n('yform_usability.table_config'));
     $select->addOptions($tables);
     $form->addRawField('</div>');
 }
-
-$form->addFieldset($addon->i18n('yform_usability.addon_settings'));
 {
-    $field = $form->addCheckboxField('use_inline_search');
+    $form->addRawField('<div data-toggle-wrapper>');
+    $field = $form->addCheckboxField('use_inline_search', empty($config) ? 1 : null);
     $field->setLabel($addon->i18n('yform_usability.search'));
-    $field->addOptions([1 => $addon->i18n('yform_usability.use_inline_search')]);
+    $field->addOptions([1 => $addon->i18n('yform_usability.all_tables')]);
+
+    $field  = $form->addSelectField('search_tables');
+    $select = $field->getSelect();
+    $select->setMultiple(true);
+    $select->addOptions($tables);
+    $form->addRawField('</div>');
 }
 
 $fragment = new \rex_fragment();


### PR DESCRIPTION
Aktuell war es nur möglich, die inline-Suche nur für alle Tabellen zu aktivieren oder zu deaktivieren.
Mit diesem Pull Request könnte man so wie bei den anderen Funktionen dann die inline-Suche speziell für einzelne Tabellen einstellbar machen.
Bei größeren Projekten ist es manchmal praktisch, wenn man bei bestimmten Tabellen, die der Kunde auch nutzen kann, die einfache Usability Suche aktivieren kann und für komplexere Tabellen, die intern vorgesehen sind oder wo man für den Kunden eine erweiterte Grundkenntnis voraussetzt, dann die komplexe Standard-Suche anbietet.

Die alte Option bleibt dabei erhalten (auch der Wert bei einem Update) -> entspricht dann wieder alle Tabellen.