### PR TITLE
Bugfix pagination does not keep yfu search filter

### DIFF
--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -198,6 +198,7 @@ class Extensions
                 unset($functions[$sIndex]);
                 $functions[] = 'yform_search';
                 $manager->setDataPageFunctions($functions);
+                $manager->setLinkVars(self::getLinkVars());
                 $ep->setSubject($manager);
             }
         }
@@ -460,5 +461,21 @@ class Extensions
             }
             $ep->setSubject($options);
         }
+    }
+
+    private static function getLinkVars(): array
+    {
+        // NOTE all params that yform usability uses for filtering
+        $params = [
+            'yfu-term',
+            'yfu-action',
+            'yfu-searchfield'
+        ];
+
+        $linkVars = [];
+        foreach ($params as $param) {
+            $linkVars[$param] = rex_get($param, 'string', '');
+        }
+        return $linkVars;
     }
 }


### PR DESCRIPTION
Aktuell funktionierte die Suche nicht in Kombination mit der Paginierung (wenn es mehr Resultate gibt als auf erste Seite angezeigt werden können). 
Beim Klick in der Pagination wurden die Such-Parameter nicht mitgenommen und die Filter nicht übernommen.
Mit diesem Bugfix werden die Filter auch für die Paginierung übergeben und die richtigen Datensätze auf Seite xy ausgegeben.