### PR TITLE
Bugfix Status toggle yorm + packages included

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -18,19 +18,6 @@ $addon = \rex_addon::get('yform_usability');
 // init all extension points
 Extensions::init();
 
-    if (\rex_request('rex-api-call', 'string') == 'yform_usability_api') {
-        // api endpoint
-        $api_result = \rex_api_yform_usability_api::factory();
-
-        \rex_api_function::handleCall();
-
-        if ($api_result && $api_result->getResult()) {
-            \rex_response::cleanOutputBuffers();
-            \rex_response::sendContent($api_result->getResult()->toJSON(), 'application/json');
-            exit;
-        }
-    }
-
 
 if (\rex::isBackend() && \rex::getUser()) {
     if ($addon->getProperty('compile')) {

--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -19,6 +19,22 @@ class Extensions
     {
         \rex_extension::register('YFORM_DATA_UPDATED', [Extensions::class, 'ext__dataUpdated']);
 
+        \rex_extension::register('PACKAGES_INCLUDED', function (){
+            if (rex_request('rex-api-call', 'string') == 'yform_usability_api') {
+                // api endpoint
+                $api_result = \rex_api_yform_usability_api::factory();
+
+                \rex_api_function::handleCall();
+
+                if ($api_result && $api_result->getResult()) {
+                    \rex_response::cleanOutputBuffers();
+                    \rex_response::setStatus(\rex_response::HTTP_OK);
+                    \rex_response::sendContent($api_result->getResult()->toJSON(), 'application/json');
+                    exit;
+                }
+            }
+        });
+
         if (\rex::isBackend()) {
             \rex_extension::register(
                 'yform/usability.getStatusColumnParams.options',

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: yform_usability
-version: '2.0.10'
+version: '2.0.11'
 author: 'Friends Of REDAXO'
 supportpage: https://github.com/FriendsOfREDAXO/yform_usability
 compile: 0


### PR DESCRIPTION
List-View Status Toggle wird mit diesem PR über Yorm gespeichert. Dadurch erhalten dann auch andere Addons wie URL Addon die Info, dass der Datensatz aktualisiert wurde.
Zudem funktionierte der EP nicht richtig, da der EP bereits gefeuert wurde, bevor die anderen Addons geladen und sich dann beim Event registrieren konnten.

https://github.com/FriendsOfREDAXO/yform_usability/issues/150