### PR TITLE
Anpassung für YForm 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## **xx.xx.20xx x.x.x**
+
+- Initiales Changelog
+- Überprüfung der Kompatibilität zu YForm 5

--- a/boot.php
+++ b/boot.php
@@ -11,6 +11,7 @@
  * file that was distributed with this source code.
  */
 
+ /** TODO: Umstellen auf den korrekten FOR-Namespace */
 namespace yform\usability;
 
 use rex;
@@ -59,6 +60,7 @@ if (rex::isBackend() && rex::getUser()) {
     }
 
     rex_yform::addTemplatePath($addon->getPath('ytemplates'));
+    /** TODO: Umstellen auf First Class Callable Syntax */
     rex_extension::register('PACKAGES_INCLUDED', [Usability::class, 'init']);
     rex_extension::register('YFORM_MANAGER_DATA_PAGE', [Extensions::class, 'ext_yformManagerDataPage']);
     rex_extension::register('YFORM_DATA_LIST', [Extensions::class, 'ext_yformDataList']);

--- a/package.yml
+++ b/package.yml
@@ -9,7 +9,7 @@ requires:
     php:
         version: '>=7, <9'
     packages:
-        yform/manager: '^4.0.2'
+        yform: '>=4.0.2, <6'
 
 pages:
     yform/manager/usability:


### PR DESCRIPTION
Soweit ich es nach Durchsicht des Codes überblicke: es gibt keinen Grund, warum das Addon nicht mit YForm 5 laufen sollte. Nur die Vorraussetzuneg gem. package.yml müssen angepsst werden, damit die Installation mit YForm 5 erfolgreich ist.

Konkrete Funktionstests bis auf die Installation auf einem YForm 5-System und Aufruf der Konfig-Seite habe ich nicht durchgeführt.  

PS: und bei der Gelegenheit mal ein Changlog eingeführt.

PPS: Versionsnummern in package.yml und Changelog habe ich nicht angepackt. Logisch