### PR TITLE
Callbacks in der "First class callable syntax"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## **xx.xx.20xx x.x.x**
+
+- Interne Optimierung (Callbacks IDE- und RexStan-freundlich in der "First class callable syntax" notiert).

--- a/boot.php
+++ b/boot.php
@@ -59,13 +59,13 @@ if (rex::isBackend() && rex::getUser()) {
     }
 
     rex_yform::addTemplatePath($addon->getPath('ytemplates'));
-    rex_extension::register('PACKAGES_INCLUDED', [Usability::class, 'init']);
-    rex_extension::register('YFORM_MANAGER_DATA_PAGE', [Extensions::class, 'ext_yformManagerDataPage']);
-    rex_extension::register('YFORM_DATA_LIST', [Extensions::class, 'ext_yformDataList']);
-    rex_extension::register('YFORM_MANAGER_REX_INFO', [Extensions::class, 'ext_yformManagerRexInfo']);
-    rex_extension::register('YFORM_DATA_LIST_QUERY', [Extensions::class, 'ext_yformDataListSql']);
-    rex_extension::register('REX_LIST_GET', [Extensions::class, 'ext_rexListGet']);
-    rex_extension::register('YFORM_DATA_LIST_ACTION_BUTTONS', [Extensions::class, 'yform_data_list_action_buttons']);
+    rex_extension::register('PACKAGES_INCLUDED', Usability::init(...));
+    rex_extension::register('YFORM_MANAGER_DATA_PAGE', Extensions::ext_yformManagerDataPage(...));
+    rex_extension::register('YFORM_DATA_LIST', Extensions::ext_yformDataList(...));
+    rex_extension::register('YFORM_MANAGER_REX_INFO', Extensions::ext_yformManagerRexInfo(...));
+    rex_extension::register('YFORM_DATA_LIST_QUERY', Extensions::ext_yformDataListSql(...));
+    rex_extension::register('REX_LIST_GET', Extensions::ext_rexListGet(...));
+    rex_extension::register('YFORM_DATA_LIST_ACTION_BUTTONS', Extensions::yform_data_list_action_buttons(...));
 
 }
 

--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -37,7 +37,7 @@ class Extensions
 {
     public static function init(): void
     {
-        rex_extension::register('YFORM_DATA_UPDATED', [Extensions::class, 'ext__dataUpdated']);
+        rex_extension::register('YFORM_DATA_UPDATED', self::ext__dataUpdated(...));
 
         rex_extension::register('PACKAGES_INCLUDED', function (){
             if (rex_request('rex-api-call', 'string') == 'yform_usability_api') {
@@ -58,7 +58,7 @@ class Extensions
         if (rex::isBackend()) {
             rex_extension::register(
                 'yform/usability.getStatusColumnParams.options',
-                [Extensions::class, 'ext__getStatusColumnOptions']
+                self::ext__getStatusColumnOptions(...)
             );
         }
     }


### PR DESCRIPTION
Callback-Methoden in der "First class callable syntax" zu notieren erleichtert IDEs und auch RexStan die automatischer Erkennung der Methoden, da in der traditionellen Schreibweise (`' klasse::methode'` bzw. `[klasse::class,'methode']` weder die IDE noch RexStan die Elemente an sich erkennen und auf Existenz prüfen. Daher: `klasse::methode(...)`.

