### PR TITLE
Status-Spalte an den Anfang verschieben

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -10,10 +10,12 @@ yform_usability.all_tables = Alle Tabellen
 yform_usability.addon_settings = Addon-Einstellungen
 yform_usability.search = Yform-Suche
 yform_usability.use_inline_search = Inline-Suche verwenden
+yform_usability.start_or_end = am Anfang statt am Ende hinzufügen
 
 yform_label.online_status = Online/Offline Status anzeigen
 yform_label.sorting = Sortierung aktiv
 yform_label.duplication = Duplizieren von Datensätzen
+yform_label.start_or_end = Status-Spalte
 
 yform_usability_action.duplicate = duplizieren
 

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -4,9 +4,11 @@ yform_label.online_status = Show online/offline state
 yform_label.sorting = Sorting active
 yform_label.duplication = Duplication active
 yform_label.all = All
+yform_label.start_or_end = Status column 
 
 yform_usability_action.duplicate = duplicate
 
 yform_usability.help_prio = <b>Order via drag&drop</b>: the table needs a field of typ <code>prio</code>. Please change the table's default order from <code>id</code> to <code>prio</code>.
 yform_usability.help_status = <b>Change dataset online-status via click</b>: the table needs a choice field with the rowname <code>status</code>, the values are freely selectable (i.e.: <code>Inaktiv=0,Aktiv=1,Pending=2,zu Erledigen=55</code>).
 yform_usability.help_open_readme = open readme
+yform_usability.start_or_end = add at the beginning instead of at the end

--- a/lang/es_es.lang
+++ b/lang/es_es.lang
@@ -4,9 +4,11 @@ yform_label.online_status = Mostrar estado en línea/fuera de línea
 yform_label.sorting = Clasificación activa
 yform_label.duplication = Duplicación activa
 yform_label.all = Todos
+yform_label.start_or_end = Columna de estado
 
 yform_usability_action.duplicate = duplicar
 
 yform_usability.help_prio = <b>Ordenar por arrastrar y soltar </b>: la tabla necesita un campo de tipo <code>prio</code>. Además, en las propiedades de la tabla, cambie la clasificación de <code>id</code> a <code>prio</code>.
 yform_usability.help_status = <b>Cambiar el estado en línea del conjunto de datos mediante el clic</b>: la tabla necesita un campo de tipo choice con el nombre de fila <code>estado</code>, los valores deben ser <code>0</code> y <code>1</code>.
 yform_usability.help_open_readme = Lecturas abiertas
+yform_usability.start_or_end = add at the beginning instead of at the end

--- a/lang/it_it.lang
+++ b/lang/it_it.lang
@@ -2,5 +2,8 @@ yform_label.online_status = Visualizza online/offline stato
 yform_label.sorting = Ordinamento attivato
 yform_label.duplication = Duplicazione attiva
 yform_label.all = Tutti
+yform_usability.start_or_end = aggiungere all'inizio invece che alla fine
+
+yform_label.start_or_end = Colonna Stato
 
 yform_usability_action.duplicate = duplicare

--- a/lang/pt_br.lang
+++ b/lang/pt_br.lang
@@ -2,9 +2,12 @@ yform_label.online_status = Exibir status online/offline
 yform_label.sorting = Triagem ativa
 yform_label.duplication = Duplicação ativa
 yform_label.all = Todos
+yform_label.start_or_end = Coluna de estado
+
 
 yform_usability_action.duplicate = Duplicar
 
 yform_usability.help_prio = <b>Order via drag&drop</b>: the table needs a field of typ <code>prio</code>. Please change the table's default order from <code>id</code> to <code>prio</code>.
 yform_usability.help_status = <b>Change dataset online-status via click</b>: the table needs a choice field with the rowname <code>status</code>, the values are freely selectable (i.e.: <code>Inaktiv=0,Aktiv=1,Pending=2,zu Erledigen=55</code>).
 yform_usability.help_open_readme = open readme
+yform_usability.start_or_end = Adicionar no início em vez de no final

--- a/lang/sv_se.lang
+++ b/lang/sv_se.lang
@@ -10,10 +10,12 @@ yform_usability.all_tables = Alla tabeller
 yform_usability.addon_settings = Addon inställningar
 yform_usability.search = YForm sök
 yform_usability.use_inline_search = Använd inline-sök
+yform_usability.start_or_end = lägg till i början istället för i slutet
 
 yform_label.online_status = Visa online / offline-status
 yform_label.sorting = Sortering aktiv
 yform_label.duplication = Duplicera poster
+yform_label.start_or_end = Statuskolumn
 
 yform_usability_action.duplicate = Duplicera
 

--- a/lib/Extensions.php
+++ b/lib/Extensions.php
@@ -65,7 +65,9 @@ class Extensions
 
     protected static function addStatusToggle($list, $table): rex_yform_list
     {
-        $list->addColumn('status_toggle', '', count($list->getColumnNames()));
+        $config = Usability::getConfig();
+        $start_or_end = ($config['start_or_end'] === '|1|') ? 2 : count($list->getColumnNames());
+        $list->addColumn('status_toggle', '', $start_or_end );
         $list->setColumnLabel('status_toggle', $list->getColumnLabel('status', rex_i18n::msg('status')));
         $list->setColumnFormat(
             'status_toggle',

--- a/pages/yform.manager.usability.php
+++ b/pages/yform.manager.usability.php
@@ -88,6 +88,13 @@ $form->addFieldset($addon->i18n('yform_usability.table_config'));
     $form->addRawField('</div>');
 }
 {
+    $form->addRawField('<div>');
+    $field = $form->addCheckboxField('start_or_end', ($config['start_or_end']) ? 1 : null);
+    $field->setLabel($addon->i18n('yform_label.start_or_end'));
+    $field->addOptions([1 => $addon->i18n('yform_usability.start_or_end')]);
+    $form->addRawField('</div>');
+}
+{
     $form->addRawField('<div data-toggle-wrapper>');
     $field = $form->addCheckboxField('use_inline_search', empty($config) ? 1 : null);
     $field->setLabel($addon->i18n('yform_usability.search'));


### PR DESCRIPTION
Unter yForm => Usability wurde eine neue Checkbox hinzugefügt, mit der man die Positionierung der STATUS-Spalte (insofern vorhanden) vom Ende der Spalten an den Anfang verschieben kann.

<img width="236" height="232" alt="Bildschirmfoto 2025-08-28 um 17 17 36" src="https://github.com/user-attachments/assets/5d26face-2ad5-438a-bd5b-d7f7d6d8e689" />

Hinweis 1: Aktuell ist die Einstellung nur global gültig, d.h. ALLE vorhandenen Tabellen werden entsprechend der Einstellung behandelt. Als Erweiterung wäre denkbar, dass dies für jede Tabelle separat justiert werden kann.

Hinweis 2: Das Update berührt keine bestehenden Daten, d.h. die Funktion muss proaktiv aktiviert werden nach dem Update.